### PR TITLE
Refactor wave spawning logic in CombatManager and WavesManager

### DIFF
--- a/Assets/Scripts/Runtime/Combat/CombatManager.cs
+++ b/Assets/Scripts/Runtime/Combat/CombatManager.cs
@@ -109,7 +109,7 @@ namespace Runtime.Combat
             ServiceLocator.Get<Energy>().GainEnergyPerIncome();
 
             // Try spawning a wave at the start of the turn
-            _wavesManager.TrySpawnWave();
+            _wavesManager.OnTurnStart();
 
             OnStartTurn?.Invoke();
         }

--- a/Assets/Scripts/Runtime/Combat/Tilemap/TilemapController.cs
+++ b/Assets/Scripts/Runtime/Combat/Tilemap/TilemapController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Runtime.Combat.Pawn;
 using Sirenix.OdinInspector;
@@ -141,6 +142,11 @@ namespace Runtime.Combat.Tilemap
             }
 
             return tilesInRange;
+        }
+
+        public List<PawnController> GetUnitsByOwnership(PawnOwner owner)
+        {
+            return _activeUnits.Where(u => u.Owner == owner).ToList();
         }
     }
 }


### PR DESCRIPTION
Replaced `TrySpawnWave` with `OnTurnStart` to streamline wave spawning and tile takeover logic. Updated `WavesManager` methods to improve clarity, remove unused fields, and simplify spawning conditions. Added support for identifying units by ownership in `TilemapController`.