### PR TITLE
Fix XML comment typo

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
@@ -45,7 +45,7 @@ namespace Runtime.CardGameplay.Card
         }
 
         /// <summary>
-        /// Remove the card from the front end of the game. Does not destroy the card from all refrence points.
+        /// Remove the card from the front end of the game. Does not destroy the card from all reference points.
         /// </summary>
         public void ReturnToPool(CardController controller)
         {


### PR DESCRIPTION
## Summary
- correct "refrence" to "reference" in `CardFactory.ReturnToPool` XML comment

## Testing
- `grep -n "reference" Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs`

------
https://chatgpt.com/codex/tasks/task_e_683f4bc8a340832a8dcdfb269711d2b8