### PR TITLE
Remove tooltip dictionary references

### DIFF
--- a/Assets/Prefabs/Card.prefab
+++ b/Assets/Prefabs/Card.prefab
@@ -1599,7 +1599,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _delayTime: 0
-  _keywordDictionary: {fileID: 11400000, guid: 66d450156de073643a2a3a33c7bc17b1, type: 2}
   _textField: {fileID: 6774713613490928545}
 --- !u!1 &8140057467381704309
 GameObject:

--- a/Assets/Prefabs/CardUI.prefab
+++ b/Assets/Prefabs/CardUI.prefab
@@ -690,7 +690,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _delayTime: 0
-  _keywordDictionary: {fileID: 11400000, guid: 66d450156de073643a2a3a33c7bc17b1, type: 2}
   _textField: {fileID: 6774713613490928545}
 --- !u!1 &8140057467381704309
 GameObject:

--- a/Assets/Scenes/Combat.unity
+++ b/Assets/Scenes/Combat.unity
@@ -3827,7 +3827,6 @@ MonoBehaviour:
   _prefab: {fileID: 5188398243834909485, guid: 79de2714e98778e45a8d6f81b5df8b9b, type: 3}
   _handController: {fileID: 303423372}
   _energy: {fileID: 1763573683}
-  _keywordDictionary: {fileID: 11400000, guid: 66d450156de073643a2a3a33c7bc17b1, type: 2}
   _discardToLocation: {fileID: 196735047}
   _drawFromLocation: {fileID: 1103476681}
 --- !u!4 &1877293997


### PR DESCRIPTION
## Summary
- remove `_keywordDictionary` references from prefabs and Combat scene

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684010893f18832aa151efbc7d60748a