### PR TITLE
Rename FormattedText field

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/DescriptionBuilder.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/DescriptionBuilder.cs
@@ -53,7 +53,7 @@ namespace Runtime.CardGameplay.Card
         public DescriptionBuilder WithKeyword(Keyword keyword)
         {
             AddNewLineIfNeeded();
-            _builder.Append($"{Hyperlink(keyword.FormatedText)}");
+            _builder.Append($"{Hyperlink(keyword.FormattedText)}");
             return this;
         }
 

--- a/Assets/Scripts/Runtime/CardGameplay/Card/View/Keyword.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/View/Keyword.cs
@@ -7,9 +7,9 @@ namespace Runtime.CardGameplay.Card.View
     [CreateAssetMenu(fileName = "Keyword", menuName = "Game/Keyword", order = 0)]
     public class Keyword : TooltipData
     {
-        [SerializeField] [Required] private string _formatedText;
+        [SerializeField] [Required] private string _formattedText;
 
-        public string FormatedText => _formatedText;
+        public string FormattedText => _formattedText;
 
         private void OnEnable()
         {


### PR DESCRIPTION
## Summary
- rename `_formatedText` to `_formattedText`
- use `FormattedText` property in `DescriptionBuilder`

## Testing
- `dotnet test --no-build -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684010a8844c832a91659b5cc515cc47