### PR TITLE
Add keyword scriptable objects

### DIFF
--- a/Assets/Resources/Data/Tooltips/Consume Keyword.asset
+++ b/Assets/Resources/Data/Tooltips/Consume Keyword.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a585236af7d242cda9720c9380782e23, type: 3}
+  m_Name: Consume Keyword
+  m_EditorClassIdentifier:
+  _header: Consume
+  _secondHeader: 
+  _description: This card can only be played once
+  _icon: {fileID: 0}
+  _backgroundColor: {r: 0.7019608, g: 0.22352941, b: 0.22352941, a: 1}
+  _alpha: 0.95
+  _formatedText: Consume

--- a/Assets/Resources/Data/Tooltips/Consume Keyword.asset.meta
+++ b/Assets/Resources/Data/Tooltips/Consume Keyword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9eb9b5d6c9e04e24918767dbd493547c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Data/Tooltips/Extract Keyword.asset
+++ b/Assets/Resources/Data/Tooltips/Extract Keyword.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a585236af7d242cda9720c9380782e23, type: 3}
+  m_Name: Extract Keyword
+  m_EditorClassIdentifier:
+  _header: Extract
+  _secondHeader: 
+  _description: Destroy the Gems that were used to play this card
+  _icon: {fileID: 0}
+  _backgroundColor: {r: 0.7019608, g: 0.22352941, b: 0.22352941, a: 1}
+  _alpha: 0.95
+  _formatedText: Extract

--- a/Assets/Resources/Data/Tooltips/Extract Keyword.asset.meta
+++ b/Assets/Resources/Data/Tooltips/Extract Keyword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbfd4f2857854755aff21188d8fb3ce8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Data/Tooltips/Find Keyword.asset
+++ b/Assets/Resources/Data/Tooltips/Find Keyword.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a585236af7d242cda9720c9380782e23, type: 3}
+  m_Name: Find Keyword
+  m_EditorClassIdentifier:
+  _header: Find
+  _secondHeader: Action
+  _description: Draw a specified Gem from the Bag
+  _icon: {fileID: -1722815243, guid: aaf06ea70717cc643b5453f87d2e7c1f, type: 3}
+  _backgroundColor: {r: 1, g: 0.69411767, b: 0.25882354, a: 1}
+  _alpha: 0.95
+  _formatedText: Find

--- a/Assets/Resources/Data/Tooltips/Find Keyword.asset.meta
+++ b/Assets/Resources/Data/Tooltips/Find Keyword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e88b8f8661c740b791786e95cec7f8f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Data/Tooltips/Overheal Keyword.asset
+++ b/Assets/Resources/Data/Tooltips/Overheal Keyword.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a585236af7d242cda9720c9380782e23, type: 3}
+  m_Name: Overheal Keyword
+  m_EditorClassIdentifier:
+  _header: Overheal
+  _secondHeader: Trigger
+  _description: If healing exceeds your maximum health, trigger this effect.
+  _icon: {fileID: 21300000, guid: 725cf42747268ab45997e177b3b9a2e4, type: 3}
+  _backgroundColor: {r: 0.4392157, g: 0.43529412, b: 0.827451, a: 1}
+  _alpha: 0.95
+  _formatedText: Overheal

--- a/Assets/Resources/Data/Tooltips/Overheal Keyword.asset.meta
+++ b/Assets/Resources/Data/Tooltips/Overheal Keyword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f69432904294a229e4de165a988fe92
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Data/Tooltips/Power Keyword.asset
+++ b/Assets/Resources/Data/Tooltips/Power Keyword.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a585236af7d242cda9720c9380782e23, type: 3}
+  m_Name: Power Keyword
+  m_EditorClassIdentifier:
+  _header: Power
+  _secondHeader: Buff
+  _description: All attacks deals more damage.
+  _icon: {fileID: -773697859, guid: aaf06ea70717cc643b5453f87d2e7c1f, type: 3}
+  _backgroundColor: {r: 0.12941177, g: 0.54901963, b: 0.45490196, a: 1}
+  _alpha: 0.95
+  _formatedText: Power

--- a/Assets/Resources/Data/Tooltips/Power Keyword.asset.meta
+++ b/Assets/Resources/Data/Tooltips/Power Keyword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70129e8774dc4515ae5b8b19ff816794
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add ScriptableObject assets for gameplay keywords: Consume, Overheal, Extract, Find and Power

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684010a3f618832aaac5271a1f6d3bbb