### PR TITLE
Fix compile errors in runtime scripts

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
@@ -6,7 +6,9 @@ using Runtime.CardGameplay.Card.CardBehaviour;
 using Runtime.Combat.Pawn;
 using Runtime.Combat.Tilemap;
 using Sirenix.OdinInspector;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace Runtime.Combat.Pawn
@@ -143,6 +145,7 @@ namespace Runtime.Combat.Pawn
             if (_summonCard) _summonCard.Image = _sprite;
         }
 
+        #if UNITY_EDITOR
         [Button(ButtonSizes.Medium)]
         public void CreateSummonCard(int cost)
         {
@@ -183,6 +186,7 @@ namespace Runtime.Combat.Pawn
 
             _summonCard = card;
         }
+        #endif
 
         [Button]
         public void WriteDescription()

--- a/Assets/Scripts/Runtime/MainMenuManager.cs
+++ b/Assets/Scripts/Runtime/MainMenuManager.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Utilities;


### PR DESCRIPTION
## Summary
- guard UnityEditor references behind preprocessor checks
- wrap summon card creation method in editor-only block

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684043b2bb40832ab6353fcf215d11a7