### PR TITLE
Introduce polymorphic strategy parameters

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/AttackTargetCardPlay.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/AttackTargetCardPlay.cs
@@ -9,14 +9,13 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
     [CreateAssetMenu(fileName = "Attack Play", menuName = "Card/Strategy/Play/Attack", order = 0)]
     public class AttackTargetCardPlay : CardPlayStrategy
     {
-        [SerializeField] private int _targetsCount;
-        [SerializeField] private TileFilterCriteria _tileFilterCriteria;
+        private AttackTargetParams _params;
 
         public override void Play(CardController cardController, Action<bool> onComplete)
         {
             SelectionService.Instance.RequestSelection(target =>
-                    target is TileView tileView && TileFilterHelper.FilterTile(tileView.Tile, _tileFilterCriteria),
-                _targetsCount,
+                    target is TileView tileView && TileFilterHelper.FilterTile(tileView.Tile, _params.TileFilter),
+                _params.TargetsCount,
                 selectedEntities =>
                 {
                     if (selectedEntities.Count > 0)
@@ -63,7 +62,13 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
 
         public override string GetDescription()
         {
-            return _targetsCount > 1 ? $"Deal {Potency} damage to {_targetsCount} targets." : $"Deal {Potency} damage.";
+            return _params.TargetsCount > 1 ? $"Deal {Potency} damage to {_params.TargetsCount} targets." : $"Deal {Potency} damage.";
+        }
+
+        public override void Initialize(PlayStrategyData playStrategyData)
+        {
+            _params = playStrategyData.Parameters as AttackTargetParams;
+            base.Initialize(playStrategyData);
         }
     }
 }

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/AttackTargetParams.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/AttackTargetParams.cs
@@ -1,0 +1,12 @@
+using System;
+using Runtime;
+
+namespace Runtime.CardGameplay.Card.CardBehaviour
+{
+    [Serializable]
+    public class AttackTargetParams : StrategyParams
+    {
+        public int TargetsCount;
+        public TileFilterCriteria TileFilter;
+    }
+}

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/CardPlayStrategy.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/CardPlayStrategy.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using UnityEngine;
+using Runtime;
 
 namespace Runtime.CardGameplay.Card.CardBehaviour
 {
     public abstract class CardPlayStrategy : ScriptableObject, IDescribable
     {
         public int Potency { get; set; }
+        public StrategyParams Params { get; private set; }
 
         public virtual string GetDescription()
         {
@@ -20,6 +22,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
         public virtual void Initialize(PlayStrategyData playStrategyData)
         {
             Potency = playStrategyData.Potency;
+            Params = playStrategyData.Parameters;
         }
     }
 }

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitParams.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitParams.cs
@@ -1,0 +1,12 @@
+using System;
+using Runtime.Combat.Pawn;
+using Runtime;
+namespace Runtime.CardGameplay.Card.CardBehaviour
+{
+    [Serializable]
+    public class SummonUnitParams : StrategyParams
+    {
+        public PawnData Unit;
+        public TileFilterCriteria TileFilter;
+    }
+}

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitPlay.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitPlay.cs
@@ -10,24 +10,14 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
     [CreateAssetMenu(fileName = "Summon Unit", menuName = "Card/Strategy/Play/Summon Unit", order = 0)]
     public class SummonUnitPlay : CardPlayStrategy
     {
-        [SerializeField] private PawnData _unit;
-        [SerializeField] private TileFilterCriteria _tileFilterCriteria;
+        private SummonUnitParams _params;
 
-        public PawnData Pawn
-        {
-            get => _unit;
-            set => _unit = value;
-        }
-
-        public TileFilterCriteria TileSelectionMode
-        {
-            get => _tileFilterCriteria;
-            set => _tileFilterCriteria = value;
-        }
+        private PawnData Pawn => _params.Unit;
+        private TileFilterCriteria TileSelectionMode => _params.TileFilter;
 
         public override void Play(CardController cardController, Action<bool> onComplete)
         {
-            SelectionService.Instance.SearchSize = _unit.Size;
+            SelectionService.Instance.SearchSize = Pawn.Size;
 
             SelectionService.Instance.RequestSelection
             (
@@ -43,7 +33,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
                     }
 
                     //get the size of the unit
-                    var unitSize = _unit.Size;
+                    var unitSize = Pawn.Size;
 
                     //get all tiles for the footprint of the unit
                     var tilemap = ServiceLocator.Get<TilemapController>();
@@ -84,7 +74,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
                         }
 
                         //all tiles must adhear to the tile selection mode
-                        if (!TileFilterHelper.FilterTile(tile, _tileFilterCriteria))
+                        if (!TileFilterHelper.FilterTile(tile, TileSelectionMode))
                         {
                             onComplete?.Invoke(false);
                             return false;
@@ -114,7 +104,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
                         return;
                     }
 
-                    var unit = _unit;
+                    var unit = Pawn;
                     var pawnController = pawnFactory.CreatePawn(unit, tile);
 
                     //deal with the card
@@ -140,6 +130,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
 
         public override void Initialize(PlayStrategyData playStrategyData)
         {
+            _params = playStrategyData.Parameters as SummonUnitParams;
             Pawn.InitializeStrategies();
             base.Initialize(playStrategyData);
         }

--- a/Assets/Scripts/Runtime/CardGameplay/Card/PlayStrategyData.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/PlayStrategyData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Runtime.CardGameplay.Card.CardBehaviour;
+using Runtime;
 using Sirenix.OdinInspector;
 
 namespace Runtime.CardGameplay.Card
@@ -8,6 +9,10 @@ namespace Runtime.CardGameplay.Card
     public struct PlayStrategyData
     {
         [LabelText("Strategy")] public CardPlayStrategy PlayStrategy;
+
+        [SerializeReference]
+        [LabelText("Params")]
+        public StrategyParams Parameters;
 
         [LabelText("Potency")] [MinValue(0)] public int Potency;
     }

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/GainStatusEffect.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/GainStatusEffect.cs
@@ -7,11 +7,17 @@ namespace Runtime.Combat.Pawn.Abilities
     [CreateAssetMenu(fileName = "Gain Status Effect", menuName = "Pawns/Abilities/Gain Status Effect", order = 0)]
     public class GainStatusEffect : PawnPlayStrategy
     {
-        [SerializeField] private StatusEffectData _statusEffectData;
+        private GainStatusEffectParams _params;
 
         public override void Play(PawnController pawn, Action<bool> onComplete)
         {
-            pawn.ApplyStatusEffect(_statusEffectData, Potency);
+            pawn.ApplyStatusEffect(_params.StatusEffect, Potency);
+        }
+
+        public override void Initialize(PawnStrategyData data)
+        {
+            _params = data.Parameters as GainStatusEffectParams;
+            base.Initialize(data);
         }
     }
 }

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/GainStatusEffectParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/GainStatusEffectParams.cs
@@ -1,0 +1,12 @@
+using System;
+using Runtime.Combat.StatusEffects;
+using Runtime;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [Serializable]
+    public class GainStatusEffectParams : StrategyParams
+    {
+        public StatusEffectData StatusEffect;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/MoveAbility.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/MoveAbility.cs
@@ -9,7 +9,7 @@ namespace Runtime.Combat.Pawn.Abilities
     [CreateAssetMenu(fileName = "Pawn Movement Ability", menuName = "Pawns/Abilities/Movement")]
     public class MoveAbility : PawnPlayStrategy
     {
-        [SerializeField] private MovementDirection _direction;
+        private MoveAbilityParams _params;
 
         public override void Play(PawnController pawn, Action<bool> onComplete)
         {
@@ -45,7 +45,7 @@ namespace Runtime.Combat.Pawn.Abilities
 
         private Vector2Int CalculateMovementVector(PawnController pawn, Vector2Int forward, int speed)
         {
-            var movement = _direction switch
+            var movement = _params.Direction switch
             {
                 MovementDirection.Forward => forward * speed,
                 MovementDirection.Backward => -forward * speed,
@@ -76,7 +76,7 @@ namespace Runtime.Combat.Pawn.Abilities
 
         public override string GetDescription()
         {
-            return _direction switch
+            return _params.Direction switch
             {
                 MovementDirection.Forward => $"Dash {Potency} tiles forward",
                 MovementDirection.Backward => $"Retreat {Potency} tiles backward",
@@ -87,6 +87,12 @@ namespace Runtime.Combat.Pawn.Abilities
                 MovementDirection.Random => $"Move in a random direction {Potency} tiles",
                 _ => throw new ArgumentOutOfRangeException()
             };
+        }
+
+        public override void Initialize(PawnStrategyData data)
+        {
+            _params = data.Parameters as MoveAbilityParams;
+            base.Initialize(data);
         }
     }
 }

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/MoveAbilityParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/MoveAbilityParams.cs
@@ -1,0 +1,12 @@
+using System;
+using Runtime.Combat.Pawn;
+using Runtime;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [Serializable]
+    public class MoveAbilityParams : StrategyParams
+    {
+        public MovementDirection Direction;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
@@ -5,6 +5,7 @@ using Runtime.CardGameplay.Card;
 using Runtime.CardGameplay.Card.CardBehaviour;
 using Runtime.Combat.Pawn;
 using Runtime.Combat.Tilemap;
+using Runtime;
 using Sirenix.OdinInspector;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -155,11 +156,14 @@ namespace Runtime.Combat.Pawn
             card.Image = _sprite;
 
             var strategy = CreateInstance<SummonUnitPlay>();
-            strategy.Pawn = this;
-            strategy.TileSelectionMode = new TileFilterCriteria
+            var parameters = new SummonUnitParams
             {
-                Occupancy = OccupancyFilter.Empty,
-                TileOwner = TileOwner.Player
+                Unit = this,
+                TileFilter = new TileFilterCriteria
+                {
+                    Occupancy = OccupancyFilter.Empty,
+                    TileOwner = TileOwner.Player
+                }
             };
 
             card.Title = _title;
@@ -170,7 +174,8 @@ namespace Runtime.Combat.Pawn
             var playStrategy = new PlayStrategyData
             {
                 PlayStrategy = strategy,
-                Potency = 1
+                Potency = 1,
+                Parameters = parameters
             };
             card.PlayStrategies = new List<PlayStrategyData> { playStrategy };
 
@@ -212,6 +217,9 @@ public struct PawnStrategyData
 {
     [Tooltip("The specific strategy applied to the pawn.")]
     public PawnPlayStrategy Strategy;
+
+    [SerializeReference]
+    public StrategyParams Parameters;
 
     [Tooltip("The potency or strength of the applied strategy.")]
     public int Potency;

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnPlayStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnPlayStrategy.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using Runtime.CardGameplay.Card;
 using UnityEngine;
+using Runtime;
 
 namespace Runtime.Combat.Pawn
 {
     public abstract class PawnPlayStrategy : ScriptableObject, IDescribable
     {
         public int Potency { get; protected set; }
+        public StrategyParams Params { get; private set; }
 
         public virtual string GetDescription()
         {
@@ -18,6 +20,7 @@ namespace Runtime.Combat.Pawn
         public virtual void Initialize(PawnStrategyData data)
         {
             Potency = data.Potency;
+            Params = data.Parameters;
         }
     }
 }

--- a/Assets/Scripts/Runtime/StrategyParams.cs
+++ b/Assets/Scripts/Runtime/StrategyParams.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Runtime
+{
+    [Serializable]
+    public abstract class StrategyParams { }
+}


### PR DESCRIPTION
## Summary
- allow card and pawn strategies to receive custom parameter objects
- implement StrategyParams base class and SerializeReference fields
- update Summon/Attack card strategies and pawn abilities to use new params
- modify Summon card creation tool to supply SummonUnitParams

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406ea0866c832aacac3c224c5dba54