### PR TITLE
Add playtesting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ To execute the unit tests, run:
 dotnet test
 ```
 
+## Playtesting
+
+Refer to the [Playtesting Guide](docs/PlaytestingGuide.md) for details on opening the project in Unity and running the `Bootstrap` scene.
+

--- a/docs/PlaytestingGuide.md
+++ b/docs/PlaytestingGuide.md
@@ -1,0 +1,19 @@
+# Playtesting Guide
+
+This guide explains how to open **Taki Fight** in Unity and run the game locally.
+
+## Required Unity Version
+
+Use **Unity 6000.0.28f1**. Make sure it is installed via the Unity Hub.
+
+## Opening the Project
+
+1. Launch Unity Hub and click **Open**.
+2. Select the repository root folder.
+3. Once the project loads, open the `Bootstrap` scene found under `Assets/Scenes`.
+4. Press **Play** to run the scene.
+
+## CI Build Artifacts
+
+The GitHub Actions workflow currently runs only the automated tests and does **not** produce build artifacts. Future builds will appear under the **Artifacts** section of a workflow run on GitHub.
+


### PR DESCRIPTION
## Summary
- add docs/PlaytestingGuide with Unity instructions
- note that CI doesn't publish artifacts yet
- link to the guide from README

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409544af1c832ab359a2d60367a945