### PR TITLE
Add coverage artifact upload

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore TakiFight.Tests/TakiFight.Tests.csproj
       - name: Run tests
-        run: dotnet test TakiFight.Tests/TakiFight.Tests.csproj --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        run: dotnet test --collect:"XPlat Code Coverage"
       - name: List Test Results
-        run: ls -R ./TestResults
+        run: ls -R **/TestResults
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:
           name: coverage-results
-          path: './TestResults/**'
+          path: '**/TestResults/**'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,9 +15,11 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore TakiFight.Tests/TakiFight.Tests.csproj
       - name: Run tests
-        run: dotnet test TakiFight.Tests/TakiFight.Tests.csproj --collect:"XPlat Code Coverage"
+        run: dotnet test TakiFight.Tests/TakiFight.Tests.csproj --collect:"XPlat Code Coverage" --results-directory ./TestResults
+      - name: List Test Results
+        run: ls -R ./TestResults
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:
           name: coverage-results
-          path: '**/TestResults/**'
+          path: './TestResults/**'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,4 +15,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore TakiFight.Tests/TakiFight.Tests.csproj
       - name: Run tests
-        run: dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal
+        run: dotnet test TakiFight.Tests/TakiFight.Tests.csproj --collect:"XPlat Code Coverage"
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-results
+          path: '**/TestResults/**'


### PR DESCRIPTION
## Summary
- collect code coverage when running unit tests
- upload the coverage folder as an artifact

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build --collect:"XPlat Code Coverage"` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68409908f6a0832a996893a4709b015d