### PR TITLE
Enable Unity build on main push

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -2,6 +2,9 @@ name: Unity Build
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- trigger Unity build workflow on push to `main`

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684098f246c8832aaaba3312cca70f18