### PR TITLE
Implement on-hit ability hook

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/DescriptionBuilder.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/DescriptionBuilder.cs
@@ -101,6 +101,9 @@ namespace Runtime.CardGameplay.Card
             // On Attack
             WithTriggeredAbilities("Strike", GetDescribableAbilities(unit.OnAttackStrategies));
 
+            // On Hit
+            WithTriggeredAbilities("Hit", GetDescribableAbilities(unit.OnHitStrategies));
+
             // On Damaged
             WithTriggeredAbilities("Revenge", GetDescribableAbilities(unit.OnDamagedStrategies));
 

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/KnockbackAbility.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/KnockbackAbility.cs
@@ -1,0 +1,62 @@
+using System;
+using Runtime.Combat.Tilemap;
+using UnityEngine;
+using Utilities;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [CreateAssetMenu(fileName = "Knockback Ability", menuName = "Pawns/Abilities/Combat/Knockback", order = 0)]
+    public class KnockbackAbility : PawnHitPlayStrategy
+    {
+        private const int DamagePerTile = 3;
+
+        public override void Play(PawnController pawn, PawnController target, ref int damage, Action<bool> onComplete)
+        {
+            if (target == null)
+            {
+                Debug.LogError("KnockbackAbility called with null target.");
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            var tilemap = ServiceLocator.Get<TilemapController>();
+            var direction = pawn.Owner == PawnOwner.Player ? Vector2Int.right : Vector2Int.left;
+            var moved = 0;
+            var anchor = target.TilemapHelper.AnchorTile.Position;
+
+            for (int i = 0; i < Potency; i++)
+            {
+                var next = anchor + direction;
+                var tile = tilemap.GetTile(next);
+                if (tile != null && !tile.IsOccupied)
+                {
+                    anchor = next;
+                    moved++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (moved > 0)
+            {
+                var tile = tilemap.GetTile(anchor);
+                target.MoveToPosition(tile, null);
+            }
+
+            if (moved < Potency)
+            {
+                int missing = Potency - moved;
+                target.Combat.ReceiveAttack(DamagePerTile * missing);
+            }
+
+            onComplete?.Invoke(true);
+        }
+
+        public override string GetDescription()
+        {
+            return $"Knockback {Potency}";
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnCombat.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnCombat.cs
@@ -50,7 +50,9 @@ namespace Runtime.Combat.Pawn
         {
             for (int i = 0; i < Attacks.Value; i++)
             {
-                target.Combat.ReceiveAttack(Damage.Value);
+                int attackDamage = Damage.Value;
+                Pawn.ExecuteHitStrategies(Pawn.Data.OnHitStrategies, target, ref attackDamage);
+                target.Combat.ReceiveAttack(attackDamage);
                 yield return null;
             }
 

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -215,6 +215,114 @@ namespace Runtime.Combat.Pawn
             }
         }
 
+        internal void ExecuteStrategies(List<PawnStrategyData> strategies, PawnController target)
+        {
+            if (strategies == null)
+            {
+                Debug.LogWarning("ExecuteStrategies: The strategies list is null.");
+                return;
+            }
+
+            foreach (var strategyData in strategies)
+            {
+                if (strategyData.Strategy == null)
+                {
+                    Debug.LogWarning("ExecuteStrategies: A strategy in the list is null.");
+                    continue;
+                }
+
+                if (strategyData.Strategy is PawnTargetPlayStrategy targeted)
+                {
+                    targeted.Play(this, target, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+                else
+                {
+                    strategyData.Strategy.Play(this, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+            }
+        }
+
+        internal void ExecuteHitStrategies(List<PawnStrategyData> strategies, PawnController target, ref int damage)
+        {
+            if (strategies == null)
+            {
+                Debug.LogWarning("ExecuteStrategies: The strategies list is null.");
+                return;
+            }
+
+            foreach (var strategyData in strategies)
+            {
+                if (strategyData.Strategy == null)
+                {
+                    Debug.LogWarning("ExecuteStrategies: A strategy in the list is null.");
+                    continue;
+                }
+
+                if (strategyData.Strategy is PawnHitPlayStrategy hitStrategy)
+                {
+                    hitStrategy.Play(this, target, ref damage, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+                else if (strategyData.Strategy is PawnTargetPlayStrategy targeted)
+                {
+                    targeted.Play(this, target, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+                else
+                {
+                    strategyData.Strategy.Play(this, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+            }
+        }
+
         public void OverrideHealthSystem(HealthSystem health)
         {
             Health = health;

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
@@ -77,6 +77,9 @@ namespace Runtime.Combat.Pawn
         [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Attack")] [SerializeField]
         private List<PawnStrategyData> _onAttackStrategies;
 
+        [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Hit")] [SerializeField]
+        private List<PawnStrategyData> _onHitStrategies;
+
         [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Move")] [SerializeField]
         private List<PawnStrategyData> _onMoveStrategies;
 
@@ -98,6 +101,7 @@ namespace Runtime.Combat.Pawn
         public List<PawnStrategyData> OnSummonStrategies => _summonStrategies;
         public List<PawnStrategyData> OnTurnStartStrategies => _onTurnStartStrategies;
         public List<PawnStrategyData> OnAttackStrategies => _onAttackStrategies;
+        public List<PawnStrategyData> OnHitStrategies => _onHitStrategies;
         public List<PawnStrategyData> OnMoveStrategies => _onMoveStrategies;
         public List<PawnStrategyData> OnDamagedStrategies => _onDamagedStrategies;
         public List<PawnStrategyData> OnKilledStrategies => _onKilledStrategies;
@@ -203,6 +207,7 @@ namespace Runtime.Combat.Pawn
         public void InitializeStrategies()
         {
             _onAttackStrategies.ForEach(data => data.Strategy.Initialize(data));
+            _onHitStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onDamagedStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onKilledStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onMoveStrategies.ForEach(data => data.Strategy.Initialize(data));

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnHitPlayStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnHitPlayStrategy.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Runtime.Combat.Pawn
+{
+    public abstract class PawnHitPlayStrategy : PawnPlayStrategy
+    {
+        public abstract void Play(PawnController pawn, PawnController target, ref int damage, Action<bool> onComplete);
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnTargetPlayStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnTargetPlayStrategy.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Runtime.Combat.Pawn
+{
+    public abstract class PawnTargetPlayStrategy : PawnPlayStrategy
+    {
+        public abstract void Play(PawnController pawn, PawnController target, Action<bool> onComplete);
+    }
+}


### PR DESCRIPTION
## Summary
- allow ability strategies to target the pawn being struck
- support modifying damage before it's applied
- add `PawnHitPlayStrategy` and execute it through `ExecuteHitStrategies`
- run hit strategies during `PawnCombat.Attack`
- update Knockback ability example

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcf52434832a9c4325a08bd55ddb