### PR TITLE
Implement fly and jump movement abilities

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/FlyAbility.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/FlyAbility.cs
@@ -1,0 +1,37 @@
+using Runtime.Combat.Tilemap;
+using UnityEngine;
+using Utilities;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [CreateAssetMenu(fileName = "Fly Ability", menuName = "Pawns/Abilities/Movement/Fly", order = 0)]
+    public class FlyAbility : PawnMovePlayStrategy
+    {
+        public override void ModifyMove(PawnController pawn, ref Tile nextTile)
+        {
+            var tilemap = ServiceLocator.Get<TilemapController>();
+            if (tilemap == null || nextTile == null) return;
+
+            var direction = pawn.Owner == PawnOwner.Player ? Vector2Int.right : Vector2Int.left;
+            var remaining = Potency <= 0 ? int.MaxValue : Potency;
+
+            var candidate = nextTile;
+            while (candidate != null && candidate.IsOccupied && remaining > 0)
+            {
+                var forwardPos = candidate.Position + direction;
+                candidate = tilemap.GetTile(forwardPos);
+                remaining--;
+            }
+
+            if (candidate != null)
+            {
+                nextTile = candidate;
+            }
+        }
+
+        public override string GetDescription()
+        {
+            return Potency > 0 ? $"Fly over up to {Potency} tiles" : "Fly";
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/JumpAbility.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/JumpAbility.cs
@@ -1,0 +1,31 @@
+using Runtime.Combat.Tilemap;
+using UnityEngine;
+using Utilities;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [CreateAssetMenu(fileName = "Jump Ability", menuName = "Pawns/Abilities/Movement/Jump", order = 0)]
+    public class JumpAbility : PawnMovePlayStrategy
+    {
+        public override void ModifyMove(PawnController pawn, ref Tile nextTile)
+        {
+            var tilemap = ServiceLocator.Get<TilemapController>();
+            if (tilemap == null || nextTile == null) return;
+
+            if (!nextTile.IsOccupied) return;
+
+            var direction = pawn.Owner == PawnOwner.Player ? Vector2Int.right : Vector2Int.left;
+            var jumpPosition = nextTile.Position + direction;
+            var candidate = tilemap.GetTile(jumpPosition);
+            if (candidate != null)
+            {
+                nextTile = candidate;
+            }
+        }
+
+        public override string GetDescription()
+        {
+            return "Jump over one tile";
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -262,6 +262,43 @@ namespace Runtime.Combat.Pawn
             }
         }
 
+        internal void ExecuteMoveStrategies(List<PawnStrategyData> strategies, ref Tile nextTile)
+        {
+            if (strategies == null)
+            {
+                Debug.LogWarning("ExecuteStrategies: The strategies list is null.");
+                return;
+            }
+
+            foreach (var strategyData in strategies)
+            {
+                if (strategyData.Strategy == null)
+                {
+                    Debug.LogWarning("ExecuteStrategies: A strategy in the list is null.");
+                    continue;
+                }
+
+                if (strategyData.Strategy is PawnMovePlayStrategy moveStrategy)
+                {
+                    moveStrategy.ModifyMove(this, ref nextTile);
+                }
+                else
+                {
+                    strategyData.Strategy.Play(this, success =>
+                    {
+                        if (!success)
+                        {
+                            Debug.LogWarning($"Strategy {strategyData.Strategy.name} failed.");
+                        }
+                        else
+                        {
+                            Debug.Log($"Strategy {strategyData.Strategy.name} succeeded.");
+                        }
+                    });
+                }
+            }
+        }
+
         internal void ExecuteHitStrategies(List<PawnStrategyData> strategies, PawnController target, ref int damage)
         {
             if (strategies == null)

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
@@ -83,6 +83,11 @@ namespace Runtime.Combat.Pawn
         [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Move")] [SerializeField]
         private List<PawnStrategyData> _onMoveStrategies;
 
+        [ListDrawerSettings(DefaultExpandedState = false)]
+        [BoxGroup("Callbacks/Movement Abilities")]
+        [SerializeField]
+        private List<PawnStrategyData> _movementAbilities;
+
         [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Damaged")] [SerializeField]
         private List<PawnStrategyData> _onDamagedStrategies;
 
@@ -103,6 +108,7 @@ namespace Runtime.Combat.Pawn
         public List<PawnStrategyData> OnAttackStrategies => _onAttackStrategies;
         public List<PawnStrategyData> OnHitStrategies => _onHitStrategies;
         public List<PawnStrategyData> OnMoveStrategies => _onMoveStrategies;
+        public List<PawnStrategyData> MovementAbilities => _movementAbilities;
         public List<PawnStrategyData> OnDamagedStrategies => _onDamagedStrategies;
         public List<PawnStrategyData> OnKilledStrategies => _onKilledStrategies;
 
@@ -211,6 +217,7 @@ namespace Runtime.Combat.Pawn
             _onDamagedStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onKilledStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onMoveStrategies.ForEach(data => data.Strategy.Initialize(data));
+            _movementAbilities.ForEach(data => data.Strategy.Initialize(data));
             _onTurnStartStrategies.ForEach(data => data.Strategy.Initialize(data));
             _summonStrategies.ForEach(data => data.Strategy.Initialize(data));
         }

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnMovePlayStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnMovePlayStrategy.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Runtime.Combat.Pawn
+{
+    /// <summary>
+    ///     Base class for abilities that can modify a pawn's movement.
+    /// </summary>
+    public abstract class PawnMovePlayStrategy : PawnPlayStrategy
+    {
+        /// <summary>
+        ///     Allows the strategy to alter the intended next tile during movement.
+        /// </summary>
+        /// <param name="pawn">The moving pawn.</param>
+        /// <param name="nextTile">Reference to the tile the pawn intends to move to. Implementations
+        /// may modify this reference to change the final destination.</param>
+        public abstract void ModifyMove(PawnController pawn, ref Runtime.Combat.Tilemap.Tile nextTile);
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnMovement.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnMovement.cs
@@ -36,6 +36,8 @@ namespace Runtime.Combat.Pawn
 
             var nextTile = GetNextTile();
 
+            _pawn.ExecuteMoveStrategies(_pawn.Data.MovementAbilities, ref nextTile);
+
             if (nextTile == null || nextTile == _tilemapHelper.AnchorTile) return false;
 
             // Check if the next tile or any tile in the footprint is occupied by another unit


### PR DESCRIPTION
## Summary
- create `PawnMovePlayStrategy` base class
- add `FlyAbility` and `JumpAbility` movement abilities
- store movement abilities in `PawnData` and initialize them
- execute movement abilities before movement logic in `PawnMovement`
- expose movement strategy execution via `PawnController`

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841631f911c832a99c4c334d9266305