### PR TITLE
Fix tilemap columns naming

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Tilemap/TilemapConfig.cs
+++ b/Assets/Scripts/Runtime/Combat/Tilemap/TilemapConfig.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Runtime.Combat.Tilemap
 {
@@ -8,9 +9,10 @@ namespace Runtime.Combat.Tilemap
     {
         [SerializeField] int rows = 3;
 
-        [SerializeField] List<TileOwner> colums = new List<TileOwner>();
+        [FormerlySerializedAs("colums")]
+        [SerializeField] List<TileOwner> columns = new List<TileOwner>();
 
         public int Rows => rows;
-        public List<TileOwner> Colums => colums;
+        public List<TileOwner> Columns => columns;
     }
 }

--- a/Assets/Scripts/Runtime/Combat/Tilemap/TilemapGenerator.cs
+++ b/Assets/Scripts/Runtime/Combat/Tilemap/TilemapGenerator.cs
@@ -14,14 +14,14 @@ namespace Runtime.Combat.Tilemap
 
             if (tilemapView == null) throw new ArgumentNullException(nameof(tilemapView));
 
-            if (config.Colums == null || config.Colums.Count == 0)
+            if (config.Columns == null || config.Columns.Count == 0)
             {
-                throw new ArgumentException("TilemapConfig must have at least one TileOwner in the colums list.");
+                throw new ArgumentException("TilemapConfig must have at least one TileOwner in the columns list.");
             }
 
             // Determine the size of the arena
             int rows = config.Rows;
-            int cols = config.Colums.Count;
+            int cols = config.Columns.Count;
 
             // Create the tilemap
             var tiles = new Tile[cols, rows];
@@ -33,8 +33,8 @@ namespace Runtime.Combat.Tilemap
                     var position = new Vector2Int(x, y);
                     tiles[x, y] = new Tile(position);
 
-                    // Assign the owner of the tile based on the colums list
-                    tiles[x, y].Owner = config.Colums[x];
+                    // Assign the owner of the tile based on the columns list
+                    tiles[x, y].Owner = config.Columns[x];
                 }
             }
 


### PR DESCRIPTION
## Summary
- fix typo in `TilemapConfig`: rename `colums` -> `columns`
- update `TilemapGenerator` to use new property name
- preserve serialization with `FormerlySerializedAs`

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417a9dc3b4832a9dedc43e439f5cea