### PR TITLE
Fix delete logic logging

### DIFF
--- a/Assets/Editor/ArtPipeline/ArtManagerWindow.ArtEntry.cs
+++ b/Assets/Editor/ArtPipeline/ArtManagerWindow.ArtEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using Runtime.CardGameplay.Card;
 using Runtime.Combat.Pawn;
 using Sirenix.OdinInspector;
@@ -156,10 +157,10 @@ namespace Editor.ArtPipeline
                 }
 
                 // Proceed with deletion
-                var failedFiles = new string[filesToDelete.Count];
-                AssetDatabase.DeleteAssets(filesToDelete.ToArray(), filesToDelete);
+                var failedFiles = new List<string>();
+                AssetDatabase.DeleteAssets(filesToDelete.ToArray(), failedFiles);
 
-                if (failedFiles.Any())
+                if (failedFiles.Count > 0)
                 {
                     Debug.LogError(
                         $"[ArtStatusWindow] Failed to delete the following files: {string.Join(", ", failedFiles)}");


### PR DESCRIPTION
## Summary
- delete outdated sprite asset with failure logging

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_68417db9ff90832aa1ab8273db9615d1