### PR TITLE
Add status effect icon support

### DIFF
--- a/Assets/Editor/ArtPipeline/ArtManagerWindow.ArtEntry.cs
+++ b/Assets/Editor/ArtPipeline/ArtManagerWindow.ArtEntry.cs
@@ -177,6 +177,7 @@ namespace Editor.ArtPipeline
                 {
                     "PawnData" => SpritePipelineSettings.Instance.CharacterSpriteFolderPath,
                     "CardData" => SpritePipelineSettings.Instance.CardSpriteFolderPath,
+                    "StatusEffectData" => SpritePipelineSettings.Instance.StatusEffectIconFolderPath,
                     _ => "unknown"
                 };
             }

--- a/Assets/Editor/ArtPipeline/ArtManagerWindow.cs
+++ b/Assets/Editor/ArtPipeline/ArtManagerWindow.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Runtime.CardGameplay.Card;
 using Runtime.Combat.Pawn;
+using Runtime.Combat.StatusEffects;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using UnityEditor;
@@ -62,6 +63,21 @@ namespace Editor.ArtPipeline
                 });
             }
 
+            // Load StatusEffectData assets
+            var statusEffectDataAssets = LoadAllAssets<StatusEffectData>();
+            foreach (var status in statusEffectDataAssets)
+            {
+                _artStatusList.Add(new ArtEntry
+                {
+                    AssetType = "StatusEffectData",
+                    AssetName = status.name,
+                    Title = status.Tooltip ? status.Tooltip.Header : status.name,
+                    SpriteReference = status.Icon,
+                    SpriteName = FindSpriteAssetName(status.Icon),
+                    DataObject = status
+                });
+            }
+
             Debug.Log("[ArtStatusWindow] Art status listing refreshed!");
         }
 
@@ -95,6 +111,7 @@ namespace Editor.ArtPipeline
             {
                 "PawnData" => SpritePipelineSettings.Instance.CharacterSpritePrefix,
                 "CardData" => SpritePipelineSettings.Instance.CardSpritePrefix,
+                "StatusEffectData" => SpritePipelineSettings.Instance.StatusEffectIconPrefix,
                 _ => "unknown"
             };
             var sanitizedAssetName = SanitizeFileName(assetName);
@@ -107,6 +124,7 @@ namespace Editor.ArtPipeline
             {
                 "PawnData" => SpritePipelineSettings.Instance.CharacterSpritePrefix,
                 "CardData" => SpritePipelineSettings.Instance.CardSpritePrefix,
+                "StatusEffectData" => SpritePipelineSettings.Instance.StatusEffectIconPrefix,
                 _ => "unknown"
             };
             var sanitizedAssetName = SanitizeFileName(assetName);

--- a/Assets/Editor/ArtPipeline/SpritePipelineSettings.cs
+++ b/Assets/Editor/ArtPipeline/SpritePipelineSettings.cs
@@ -15,11 +15,18 @@ namespace Editor.ArtPipeline
         [Tooltip("Prefix to identify card sprites (e.g., 'card').")]
         public string CardSpritePrefix = "card";
 
+        [Tooltip("Prefix to identify status effect icons (e.g., 'status').")]
+        public string StatusEffectIconPrefix = "status";
+
         [FolderPath] [Tooltip("Path to the folder where card sprites are stored.")]
         public string CardSpriteFolderPath = "Assets/Resources/Sprites/Cards";
 
         [FolderPath] [Tooltip("Path to the folder where character sprites are stored.")]
         public string CharacterSpriteFolderPath = "Assets/Resources/Sprites/Characters";
+
+        [FolderPath]
+        [Tooltip("Path to the folder where status effect icons are stored.")]
+        public string StatusEffectIconFolderPath = "Assets/Resources/Sprites/StatusEffects";
 
         public static SpritePipelineSettings Instance
         {


### PR DESCRIPTION
## Summary
- extend pipeline settings with status effect icon prefix and folder
- list `StatusEffectData` assets in `ArtManagerWindow`
- handle status effect folder path and prefix when importing sprites

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417dafb8f4832abcdc86710cfcecb5