### PR TITLE
Upload builds to Drive

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -27,3 +27,15 @@ jobs:
         with:
           name: ${{ matrix.targetPlatform }}-build
           path: build/${{ matrix.targetPlatform }}
+      - name: Install rclone
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone
+      - name: Upload to Drive
+        env:
+          DRIVE_SERVICE_ACCOUNT_KEY: ${{ secrets.DRIVE_SERVICE_ACCOUNT_KEY }}
+          DRIVE_BUILD_FOLDER: ${{ secrets.DRIVE_BUILD_FOLDER }}
+        run: |
+          echo "$DRIVE_SERVICE_ACCOUNT_KEY" > service-account.json
+          rclone config create buildremote drive service_account_file service-account.json --config rclone.conf
+          rclone copy "build/${{ matrix.targetPlatform }}" buildremote:"$DRIVE_BUILD_FOLDER"/${{ matrix.targetPlatform }} --config rclone.conf --create-empty-src-dirs


### PR DESCRIPTION
## Summary
- run rclone after the Unity build job to copy artifacts to Google Drive

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2c9bbb4832aa582cedff33cf20b