### PR TITLE
Add Discord notification after Unity build

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -27,3 +27,13 @@ jobs:
         with:
           name: ${{ matrix.targetPlatform }}-build
           path: build/${{ matrix.targetPlatform }}
+
+  notify:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Post Discord Update
+        env:
+          PLAYTEST_DISCORD_UPDATE: ${{ secrets.PLAYTEST_DISCORD_UPDATE }}
+        run: ./scripts/post_discord_update.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2024-06-15
+### Added
+- Added Discord notification pipeline.
+### Changed
+- Minor improvements.
+
+## [0.1.0] - 2024-05-01
+### Added
+- Initial release.

--- a/scripts/post_discord_update.sh
+++ b/scripts/post_discord_update.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+CHANGELOG_FILE=${CHANGELOG_FILE:-CHANGELOG.md}
+WEBHOOK_URL=${PLAYTEST_DISCORD_UPDATE:?"PLAYTEST_DISCORD_UPDATE not set"}
+
+# Extract latest changelog entry
+header=$(grep -m 1 '^## ' "$CHANGELOG_FILE" | sed 's/^## //')
+notes=$(awk '/^## /{if(found) exit; found=1; next} found{print}' "$CHANGELOG_FILE")
+
+content="**$header**\n$notes"
+
+payload=$(jq -n --arg content "$content" '{content:$content}')
+
+curl -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- create CHANGELOG with sample entries
- add script `post_discord_update.sh` to send the latest changelog entry to Discord
- update Unity build workflow to send Discord notification after builds

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6846c2af98e0832aa89ce2d92944e19e