### PR TITLE
Fix recalled pawn health

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardController.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardController.cs
@@ -86,19 +86,32 @@ namespace Runtime.CardGameplay.Card
                 return;
             }
 
-
-            Instance = new CardInstance(data)
+            var instance = new CardInstance(data)
             {
                 Controller = this
             };
 
+            Init(instance, dependencies);
+        }
+
+        public void Init(CardInstance instance, CardDependencies dependencies)
+        {
+            if (instance == null)
+            {
+                Debug.LogError("CardInstance cannot be null during initialization.");
+                return;
+            }
+
+            Instance = instance;
+            Instance.Controller = this;
+
+            var data = instance.Data;
 
             CardType = data.CardType;
 
             _feedbackStrategy = data.FeedbackStrategy;
             _playStrategies = new List<PlayStrategyData>(data.PlayStrategies);
             _playStrategies.ForEach(s => s.PlayStrategy.Initialize(s));
-
 
             _cardFactory = ServiceLocator.Get<CardFactory>();
             Energy = ServiceLocator.Get<Energy.Energy>();

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
@@ -41,7 +41,13 @@ namespace Runtime.CardGameplay.Card
 
         public CardController Create(CardInstance instance)
         {
-            return Create(instance.Data);
+            CardController controller = GetController();
+            controller.Init(instance, _cardDependencies);
+            controller.gameObject.GetComponent<CardView>()
+                .Init(_drawFromLocation, _discardToLocation)
+                .Draw(controller);
+            controller.gameObject.SetActive(true);
+            return controller;
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -38,6 +38,11 @@ namespace Runtime.Combat.Pawn
         public CardInstance AssociatedCard { get; internal set; }
         public PawnInstant Instant { get; private set; }
 
+        internal void SetInstant(PawnInstant instant)
+        {
+            Instant = instant;
+        }
+
         public bool IsActive { get; private set; }
         public event Action OnKilled;
 

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnFactory.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnFactory.cs
@@ -43,6 +43,7 @@ namespace Runtime.Combat.Pawn
 
             var data = instant.Data;
             var controller = CreatePawn(data, tile);
+            controller.SetInstant(instant);
             controller.Health.SetHealth(instant.CurrentHealth);
             return controller;
         }


### PR DESCRIPTION
## Summary
- ensure `CardInstance` survives hand instantiation
- allow creating card controllers from a `CardInstance`
- track pawn health with `PawnInstant` when respawning

## Testing
- `dotnet` was not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6848050a5504832a84f8ae2abda00074