### PR TITLE
Install jq in post-update workflow

### DIFF
--- a/.github/workflows/post-update.yml
+++ b/.github/workflows/post-update.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
       - name: Send changelog entry
         env:
           PLAYTEST_DISCORD_UPDATE: ${{ secrets.PLAYTEST_DISCORD_UPDATE }}


### PR DESCRIPTION
## Summary
- install `jq` in the post-update workflow so the log script works properly

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847faae00a0832a983eb93bfac72ed3