### PR TITLE
Add NuGet cache to CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+          cache: 'nuget'
+          cache-dependency-path: '**/*.csproj'
       - name: Restore dependencies
         run: dotnet restore TakiFight.Tests/TakiFight.Tests.csproj
       - name: Run tests


### PR DESCRIPTION
## Summary
- use setup-dotnet cache to speed up restore

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847faa8e198832aa8fff4d9c7db9193