### PR TITLE
Add attack feedback system

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackParams.cs
@@ -1,0 +1,12 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [Serializable]
+    public class AttackFeedbackParams : StrategyParams
+    {
+        public AnimationClip Animation;
+        public GameObject VfxPrefab;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategy.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    public abstract class AttackFeedbackStrategy : ScriptableObject
+    {
+        public abstract void Play(PawnController attacker, PawnController target, Action onComplete);
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/IdleAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/IdleAttackFeedbackStrategy.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [CreateAssetMenu(fileName = "Idle Attack Feedback", menuName = "Pawns/Attack Feedback/Idle")]
+    public class IdleAttackFeedbackStrategy : AttackFeedbackStrategy
+    {
+        [SerializeField] private AttackFeedbackParams _params;
+
+        public override void Play(PawnController attacker, PawnController target, Action onComplete)
+        {
+            if (!attacker)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            PlayEffects(attacker, _params);
+            onComplete?.Invoke();
+        }
+
+        private static void PlayEffects(PawnController pawn, AttackFeedbackParams parameters)
+        {
+            if (parameters == null)
+            {
+                return;
+            }
+
+            if (parameters.Animation)
+            {
+                var animator = pawn.GetComponent<Animator>();
+                animator?.Play(parameters.Animation.name);
+            }
+
+            if (parameters.VfxPrefab)
+            {
+                var vfx = Instantiate(parameters.VfxPrefab, pawn.transform.position, Quaternion.identity);
+                Destroy(vfx, 2f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackParams.cs
@@ -1,0 +1,11 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [Serializable]
+    public class MeleeAttackFeedbackParams : AttackFeedbackParams
+    {
+        public float MoveDuration = 0.25f;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
@@ -1,0 +1,48 @@
+using System;
+using DG.Tweening;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [CreateAssetMenu(fileName = "Melee Attack Feedback", menuName = "Pawns/Attack Feedback/Melee")]
+    public class MeleeAttackFeedbackStrategy : AttackFeedbackStrategy
+    {
+        [SerializeField] private MeleeAttackFeedbackParams _params;
+
+        public override void Play(PawnController attacker, PawnController target, Action onComplete)
+        {
+            if (!attacker || !target)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            var origin = attacker.transform.position;
+            var sequence = DOTween.Sequence();
+            sequence.Append(attacker.transform.DOMove(target.transform.position, _params.MoveDuration));
+            sequence.AppendCallback(() => PlayEffects(attacker, _params));
+            sequence.Append(attacker.transform.DOMove(origin, _params.MoveDuration));
+            sequence.OnComplete(() => onComplete?.Invoke());
+        }
+
+        private static void PlayEffects(PawnController pawn, AttackFeedbackParams parameters)
+        {
+            if (parameters == null)
+            {
+                return;
+            }
+
+            if (parameters.Animation)
+            {
+                var animator = pawn.GetComponent<Animator>();
+                animator?.Play(parameters.Animation.name);
+            }
+
+            if (parameters.VfxPrefab)
+            {
+                var vfx = Object.Instantiate(parameters.VfxPrefab, pawn.transform.position, Quaternion.identity);
+                Object.Destroy(vfx, 2f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackParams.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [Serializable]
+    public class ProjectileAttackFeedbackParams : AttackFeedbackParams
+    {
+        public GameObject ProjectilePrefab;
+        public GameObject ImpactVfxPrefab;
+        public float ProjectileDuration = 0.25f;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackStrategy.cs
@@ -1,0 +1,53 @@
+using System;
+using DG.Tweening;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [CreateAssetMenu(fileName = "Projectile Attack Feedback", menuName = "Pawns/Attack Feedback/Projectile")]
+    public class ProjectileAttackFeedbackStrategy : AttackFeedbackStrategy
+    {
+        [SerializeField] private ProjectileAttackFeedbackParams _params;
+
+        public override void Play(PawnController attacker, PawnController target, Action onComplete)
+        {
+            if (!attacker || !target || _params == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            GameObject projectile = null;
+            if (_params.ProjectilePrefab)
+            {
+                projectile = Instantiate(_params.ProjectilePrefab, attacker.transform.position, Quaternion.identity);
+            }
+
+            var sequence = DOTween.Sequence();
+            if (projectile)
+            {
+                sequence.Append(projectile.transform.DOMove(target.transform.position, _params.ProjectileDuration));
+            }
+            else
+            {
+                sequence.AppendInterval(_params.ProjectileDuration);
+            }
+
+            sequence.AppendCallback(() =>
+            {
+                if (_params.ImpactVfxPrefab)
+                {
+                    var impact = Instantiate(_params.ImpactVfxPrefab, target.transform.position, Quaternion.identity);
+                    Destroy(impact, 2f);
+                }
+
+                if (projectile)
+                {
+                    Destroy(projectile);
+                }
+            });
+
+            sequence.OnComplete(() => onComplete?.Invoke());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AttackFeedbackStrategy` base class for combat animations
- implement idle, melee, and projectile feedback strategies
- create serializable parameter classes for animations, prefabs, and durations

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684959cb2844832a902c47e7c90e95af