### PR TITLE
Add attack feedback logic

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
@@ -1,5 +1,4 @@
 using System;
-using DG.Tweening;
 using UnityEngine;
 
 namespace Runtime.Combat.Pawn.AttackFeedback
@@ -17,12 +16,14 @@ namespace Runtime.Combat.Pawn.AttackFeedback
                 return;
             }
 
-            var origin = attacker.transform.position;
-            var sequence = DOTween.Sequence();
-            sequence.Append(attacker.transform.DOMove(target.transform.position, _params.MoveDuration));
-            sequence.AppendCallback(() => PlayEffects(attacker, _params));
-            sequence.Append(attacker.transform.DOMove(origin, _params.MoveDuration));
-            sequence.OnComplete(() => onComplete?.Invoke());
+            var origin = attacker.TilemapHelper.AnchorTile.Position;
+            var destination = target.TilemapHelper.AnchorTile.Position;
+
+            attacker.View.MoveToPosition(destination, () =>
+            {
+                PlayEffects(attacker, _params);
+                attacker.View.MoveToPosition(origin, onComplete);
+            });
         }
 
         private static void PlayEffects(PawnController pawn, AttackFeedbackParams parameters)

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnCombat.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnCombat.cs
@@ -50,6 +50,10 @@ namespace Runtime.Combat.Pawn
         {
             for (int i = 0; i < Attacks.Value; i++)
             {
+                var feedbackDone = false;
+                Pawn.ExecuteAttackFeedbackStrategy(target, () => feedbackDone = true);
+                yield return new WaitUntil(() => feedbackDone);
+
                 int attackDamage = Damage.Value;
                 Pawn.ExecuteHitStrategies(Pawn.Data.OnHitStrategies, target, ref attackDamage);
                 target.Combat.ReceiveAttack(attackDamage);

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -5,6 +5,7 @@ using CodeMonkey.HealthSystemCM;
 using JetBrains.Annotations;
 using Runtime.Combat.StatusEffects;
 using Runtime.Combat.Tilemap;
+using Runtime.Combat.Pawn.AttackFeedback;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -19,6 +20,7 @@ namespace Runtime.Combat.Pawn
         [SerializeField] private PawnCombat _combat;
         [SerializeField] private PawnTilemapHelper _tilemapHelper;
         [SerializeField] private PawnMovement _movement;
+        [SerializeField] private AttackFeedbackStrategy _attackFeedbackStrategy;
 
         public PawnOwner Owner { get; set; }
 
@@ -32,6 +34,7 @@ namespace Runtime.Combat.Pawn
         internal PawnTilemapHelper TilemapHelper => _tilemapHelper;
         internal PawnMovement Movement => _movement;
         public PawnView View => _view;
+        internal AttackFeedbackStrategy AttackFeedbackStrategy => _attackFeedbackStrategy;
         public event Action OnKilled;
 
         public void Init(PawnData data)
@@ -61,6 +64,7 @@ namespace Runtime.Combat.Pawn
             gameObject.name = $"{data.name}_{Guid.NewGuid()}";
 
             Data = data;
+            _attackFeedbackStrategy = data.AttackFeedbackStrategy;
 
             // Execute onSummon strategies
             ExecuteStrategies(data.OnSummonStrategies);
@@ -358,6 +362,17 @@ namespace Runtime.Combat.Pawn
                     });
                 }
             }
+        }
+
+        internal void ExecuteAttackFeedbackStrategy(PawnController target, Action onComplete)
+        {
+            if (_attackFeedbackStrategy == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            _attackFeedbackStrategy.Play(this, target, onComplete);
         }
 
         public void OverrideHealthSystem(HealthSystem health)


### PR DESCRIPTION
## Summary
- expose `AttackFeedbackStrategy` on `PawnController`
- wait for feedback strategy when executing attacks
- reuse view tweening in melee feedback

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68495f4469f8832a9f1efd6054aebce7