### PR TITLE
Implement AttackFeedbackStrategyData refactor

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategy.cs
@@ -5,7 +5,7 @@ namespace Runtime.Combat.Pawn.AttackFeedback
 {
     public abstract class AttackFeedbackStrategy : ScriptableObject
     {
-        public virtual void Initialize()
+        public virtual void Initialize(AttackFeedbackStrategyData data)
         {
         }
 

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategyData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/AttackFeedbackStrategyData.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+namespace Runtime.Combat.Pawn.AttackFeedback
+{
+    [Serializable]
+    public struct AttackFeedbackStrategyData
+    {
+        public AttackFeedbackStrategy Strategy;
+
+        [SerializeReference]
+        public StrategyParams Parameters;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/IdleAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/IdleAttackFeedbackStrategy.cs
@@ -6,7 +6,12 @@ namespace Runtime.Combat.Pawn.AttackFeedback
     [CreateAssetMenu(fileName = "Idle Attack Feedback", menuName = "Pawns/Attack Feedback/Idle")]
     public class IdleAttackFeedbackStrategy : AttackFeedbackStrategy
     {
-        [SerializeField] private AttackFeedbackParams _params;
+        private AttackFeedbackParams _params;
+
+        public override void Initialize(AttackFeedbackStrategyData data)
+        {
+            _params = data.Parameters as AttackFeedbackParams;
+        }
 
         public override void Play(PawnController attacker, PawnController target, Action onComplete)
         {

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/MeleeAttackFeedbackStrategy.cs
@@ -6,7 +6,12 @@ namespace Runtime.Combat.Pawn.AttackFeedback
     [CreateAssetMenu(fileName = "Melee Attack Feedback", menuName = "Pawns/Attack Feedback/Melee")]
     public class MeleeAttackFeedbackStrategy : AttackFeedbackStrategy
     {
-        [SerializeField] private MeleeAttackFeedbackParams _params;
+        private MeleeAttackFeedbackParams _params;
+
+        public override void Initialize(AttackFeedbackStrategyData data)
+        {
+            _params = data.Parameters as MeleeAttackFeedbackParams;
+        }
 
         public override void Play(PawnController attacker, PawnController target, Action onComplete)
         {

--- a/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackStrategy.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/AttackFeedback/ProjectileAttackFeedbackStrategy.cs
@@ -7,7 +7,12 @@ namespace Runtime.Combat.Pawn.AttackFeedback
     [CreateAssetMenu(fileName = "Projectile Attack Feedback", menuName = "Pawns/Attack Feedback/Projectile")]
     public class ProjectileAttackFeedbackStrategy : AttackFeedbackStrategy
     {
-        [SerializeField] private ProjectileAttackFeedbackParams _params;
+        private ProjectileAttackFeedbackParams _params;
+
+        public override void Initialize(AttackFeedbackStrategyData data)
+        {
+            _params = data.Parameters as ProjectileAttackFeedbackParams;
+        }
 
         public override void Play(PawnController attacker, PawnController target, Action onComplete)
         {

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -20,7 +20,7 @@ namespace Runtime.Combat.Pawn
         [SerializeField] private PawnCombat _combat;
         [SerializeField] private PawnTilemapHelper _tilemapHelper;
         [SerializeField] private PawnMovement _movement;
-        [SerializeField] private AttackFeedbackStrategy _attackFeedbackStrategy;
+        [SerializeField] private AttackFeedbackStrategyData _attackFeedbackStrategy;
 
         public PawnOwner Owner { get; set; }
 
@@ -34,7 +34,7 @@ namespace Runtime.Combat.Pawn
         internal PawnTilemapHelper TilemapHelper => _tilemapHelper;
         internal PawnMovement Movement => _movement;
         public PawnView View => _view;
-        internal AttackFeedbackStrategy AttackFeedbackStrategy => _attackFeedbackStrategy;
+        internal AttackFeedbackStrategy AttackFeedbackStrategy => _attackFeedbackStrategy.Strategy;
         public event Action OnKilled;
 
         public void Init(PawnData data)
@@ -366,13 +366,13 @@ namespace Runtime.Combat.Pawn
 
         internal void ExecuteAttackFeedbackStrategy(PawnController target, Action onComplete)
         {
-            if (_attackFeedbackStrategy == null)
+            if (_attackFeedbackStrategy.Strategy == null)
             {
                 onComplete?.Invoke();
                 return;
             }
 
-            _attackFeedbackStrategy.Play(this, target, onComplete);
+            _attackFeedbackStrategy.Strategy.Play(this, target, onComplete);
         }
 
         public void OverrideHealthSystem(HealthSystem health)

--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnData.cs
@@ -79,7 +79,7 @@ namespace Runtime.Combat.Pawn
         private List<PawnStrategyData> _onAttackStrategies;
 
         [BoxGroup("Callbacks/On Attack")] [SerializeField]
-        private AttackFeedback.AttackFeedbackStrategy _attackFeedbackStrategy;
+        private AttackFeedback.AttackFeedbackStrategyData _attackFeedbackStrategy;
 
         [ListDrawerSettings(DefaultExpandedState = false)] [BoxGroup("Callbacks/On Hit")] [SerializeField]
         private List<PawnStrategyData> _onHitStrategies;
@@ -110,7 +110,7 @@ namespace Runtime.Combat.Pawn
         public List<PawnStrategyData> OnSummonStrategies => _summonStrategies;
         public List<PawnStrategyData> OnTurnStartStrategies => _onTurnStartStrategies;
         public List<PawnStrategyData> OnAttackStrategies => _onAttackStrategies;
-        public AttackFeedback.AttackFeedbackStrategy AttackFeedbackStrategy => _attackFeedbackStrategy;
+        public AttackFeedback.AttackFeedbackStrategyData AttackFeedbackStrategy => _attackFeedbackStrategy;
         public List<PawnStrategyData> OnHitStrategies => _onHitStrategies;
         public List<PawnStrategyData> OnMoveStrategies => _onMoveStrategies;
         public List<PawnStrategyData> MovementAbilities => _movementAbilities;
@@ -217,7 +217,10 @@ namespace Runtime.Combat.Pawn
 
         public void InitializeStrategies()
         {
-            _attackFeedbackStrategy?.Initialize();
+            if (_attackFeedbackStrategy.Strategy != null)
+            {
+                _attackFeedbackStrategy.Strategy.Initialize(_attackFeedbackStrategy);
+            }
             _onAttackStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onHitStrategies.ForEach(data => data.Strategy.Initialize(data));
             _onDamagedStrategies.ForEach(data => data.Strategy.Initialize(data));

--- a/TakiFight.Tests/PawnCombatTestStubs.cs
+++ b/TakiFight.Tests/PawnCombatTestStubs.cs
@@ -11,7 +11,7 @@ namespace Runtime.Combat.Pawn
         public int Defense { get; set; }
         public int Damage { get; set; }
         public int Attacks { get; set; }
-        public AttackFeedback.AttackFeedbackStrategy AttackFeedbackStrategy { get; set; }
+        public AttackFeedback.AttackFeedbackStrategyData AttackFeedbackStrategy { get; set; }
         public List<PawnStrategyData> OnHitStrategies { get; } = new();
         public List<PawnStrategyData> OnAttackStrategies { get; } = new();
     }
@@ -61,7 +61,7 @@ namespace Runtime.Combat.Pawn
 
         public IEnumerator Attack(PawnController target, Action onComplete)
         {
-            Pawn.Data.AttackFeedbackStrategy?.Play(Pawn, target, null);
+            Pawn.Data.AttackFeedbackStrategy.Strategy?.Play(Pawn, target, null);
 
             for (int i = 0; i < Attacks.Value; i++)
             {

--- a/TakiFight.Tests/PawnCombatTests.cs
+++ b/TakiFight.Tests/PawnCombatTests.cs
@@ -12,7 +12,11 @@ namespace TakiFight.Tests
             var attackerData = new PawnData { Damage = 1, Defense = 0, Attacks = 1 };
             var targetData = new PawnData { Damage = 0, Defense = 0, Attacks = 0 };
             var feedback = new TestAttackFeedbackStrategy();
-            attackerData.AttackFeedbackStrategy = feedback;
+            attackerData.AttackFeedbackStrategy = new AttackFeedbackStrategyData
+            {
+                Strategy = feedback,
+                Parameters = null
+            };
 
             var attacker = new PawnController();
             attacker.Init(attackerData);

--- a/TakiFight.Tests/StrategyParams.cs
+++ b/TakiFight.Tests/StrategyParams.cs
@@ -1,0 +1,4 @@
+namespace Runtime
+{
+    public abstract class StrategyParams { }
+}

--- a/TakiFight.Tests/TestAttackFeedbackStrategy.cs
+++ b/TakiFight.Tests/TestAttackFeedbackStrategy.cs
@@ -4,9 +4,15 @@ using UnityEngine;
 
 namespace Runtime.Combat.Pawn.AttackFeedback
 {
+    public struct AttackFeedbackStrategyData
+    {
+        public AttackFeedbackStrategy Strategy;
+        public StrategyParams Parameters;
+    }
+
     public abstract class AttackFeedbackStrategy : ScriptableObject
     {
-        public virtual void Initialize()
+        public virtual void Initialize(AttackFeedbackStrategyData data)
         {
         }
 


### PR DESCRIPTION
## Summary
- add `AttackFeedbackStrategyData` struct for configuring attack feedback
- update strategies to initialize from data
- refactor `PawnData`, `PawnController` and related code to use the new data
- update test stubs and unit tests

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684976fbb858832a847142b12318bd4b