### PR TITLE
Return summon card after pawn death

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitPlay.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/SummonUnitPlay.cs
@@ -107,13 +107,7 @@ namespace Runtime.CardGameplay.Card.CardBehaviour
                     var unit = Pawn;
                     var pawnController = pawnFactory.CreatePawn(unit, tile);
 
-                    //deal with the card
-                    // //the card is moved to a "limbo" state where it dosen't have a controller 
-                    // //we remove it from the hand without adding it to the discard pile or the consume pile
-                    // cardController.Limbo();
-                    // //when the pawn is killed, we move the card to the consume pile
-                    // pawnController.OnKilled += cardController.Consume;
-
+                    pawnController.AssignSummonCard(cardController);
 
                     onComplete?.Invoke(true);
                 },

--- a/Assets/Scripts/Runtime/CardGameplay/Deck/HandController.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Deck/HandController.cs
@@ -66,6 +66,21 @@ namespace Runtime.CardGameplay.Deck
             OnCardAdded?.Invoke(cardController);
         }
 
+        public void AddCardToHand(CardController cardController)
+        {
+            if (cardController == null)
+            {
+                Debug.LogWarning("Trying to add null card to hand");
+                return;
+            }
+
+            if (_cards.Count >= _maxHandSize) return;
+
+            cardController.OnDraw();
+            cardController.View.OnDraw();
+            AddCard(cardController);
+        }
+
         /// <summary>
         /// Draw a card from the deck, create for it a game object and add it to the hand
         /// </summary>


### PR DESCRIPTION
## Summary
- allow `HandController` to re-add an existing card to the hand
- store the card that summoned a pawn in `PawnController`
- return the stored card to the hand with +1 cost when the pawn dies
- hook summon card tracking in `SummonUnitPlay`

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acd5b37e0832a933bea1a81f7c28c