### PR TITLE
Introduce card instance initialization

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardController.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardController.cs
@@ -86,19 +86,26 @@ namespace Runtime.CardGameplay.Card
                 return;
             }
 
+            CardInstance cardInstance = new CardInstance(data);
+            Init(cardInstance, dependencies);
+        }
 
-            Instance = new CardInstance(data)
+        public void Init(CardInstance instance, CardDependencies deps)
+        {
+            if (instance == null)
             {
-                Controller = this
-            };
+                Debug.LogError("CardInstance cannot be null during initialization.");
+                return;
+            }
 
+            Instance = instance;
+            Instance.Controller = this;
 
-            CardType = data.CardType;
+            CardType = instance.Data.CardType;
 
-            _feedbackStrategy = data.FeedbackStrategy;
-            _playStrategies = new List<PlayStrategyData>(data.PlayStrategies);
+            _feedbackStrategy = instance.Data.FeedbackStrategy;
+            _playStrategies = new List<PlayStrategyData>(instance.Data.PlayStrategies);
             _playStrategies.ForEach(s => s.PlayStrategy.Initialize(s));
-
 
             _cardFactory = ServiceLocator.Get<CardFactory>();
             Energy = ServiceLocator.Get<Energy.Energy>();
@@ -109,11 +116,9 @@ namespace Runtime.CardGameplay.Card
             IsPlayable = new Observable<bool>(true);
             OnCardPlayedEvent += _ => UpdateAffordability();
             Energy.OnAmountChanged += _ => UpdateAffordability();
-            Data = data;
+            Data = instance.Data;
 
-            // SelectionService.Instance.Register(this);
-
-            gameObject.name = data.Title + Instance.Guid;
+            gameObject.name = instance.Data.Title + instance.Guid;
         }
 
         private void UpdateAffordability()

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardFactory.cs
@@ -30,18 +30,19 @@ namespace Runtime.CardGameplay.Card
         [Button]
         public CardController Create(CardData data)
         {
+            var instance = new CardInstance(data);
+            return Create(instance);
+        }
+
+        public CardController Create(CardInstance instance)
+        {
             CardController controller = GetController();
-            controller.Init(data, _cardDependencies);
+            controller.Init(instance, _cardDependencies);
             controller.gameObject.GetComponent<CardView>()
                 .Init(_drawFromLocation, _discardToLocation)
                 .Draw(controller);
             controller.gameObject.SetActive(true);
             return controller;
-        }
-
-        public CardController Create(CardInstance instance)
-        {
-            return Create(instance.Data);
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/CardGameplay/Deck/HandController.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Deck/HandController.cs
@@ -66,6 +66,19 @@ namespace Runtime.CardGameplay.Deck
             OnCardAdded?.Invoke(cardController);
         }
 
+        public void AddCardFromInstance(CardInstance instance)
+        {
+            if (_cards.Count >= _maxHandSize)
+            {
+                return;
+            }
+
+            CardController controller = _cardFactory.Create(instance);
+            controller.OnDraw();
+            controller.View.OnDraw();
+            AddCard(controller);
+        }
+
         /// <summary>
         /// Draw a card from the deck, create for it a game object and add it to the hand
         /// </summary>


### PR DESCRIPTION
## Summary
- allow `CardController` to initialize from an existing `CardInstance`
- update `CardFactory` to support creating controllers from a given instance
- enable adding a card to the hand directly from a `CardInstance`

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acd67e388832a9b65a826a48a9719