### PR TITLE
Fix pawn recall duplication and update tests

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/PawnController.cs
@@ -24,6 +24,7 @@ namespace Runtime.Combat.Pawn
         [SerializeField] private PawnMovement _movement;
         [SerializeField] private AttackFeedbackStrategyData _attackFeedbackStrategy;
         private CardInstance _summonCardInstance;
+        private bool _isBeingKilled;
 
         public PawnOwner Owner { get; set; }
 
@@ -83,6 +84,13 @@ namespace Runtime.Combat.Pawn
 
         private void Kill()
         {
+            if (_isBeingKilled)
+            {
+                return;
+            }
+
+            _isBeingKilled = true;
+
             ExecuteStrategies(Data.OnKilledStrategies);
             if (!IsCardless)
             {
@@ -119,10 +127,12 @@ namespace Runtime.Combat.Pawn
 
         public void Recall()
         {
-            _summonCardInstance.Controller.Cost += 1;
+            _summonCardInstance.Cost += 1;
+
             var hand = ServiceLocator.Get<HandController>();
             hand.RemoveFromLimbo(_summonCardInstance);
             hand?.AddCardFromInstant(_summonCardInstance);
+
             Debug.Log($"{_summonCardInstance} has been recalled");
         }
 

--- a/TakiFight.Tests/SummonCardReturnTests.cs
+++ b/TakiFight.Tests/SummonCardReturnTests.cs
@@ -23,10 +23,17 @@ public class SummonCardReturnTests
 
     private class Pawn
     {
+        private bool _isDead;
         public event Action OnKilled;
 
         public void Kill()
         {
+            if (_isDead)
+            {
+                return;
+            }
+
+            _isDead = true;
             OnKilled?.Invoke();
         }
     }
@@ -68,6 +75,21 @@ public class SummonCardReturnTests
         var summon = new SummonUnitPlay(hand, card, true);
 
         var pawn = summon.Summon();
+        pawn.Kill();
+
+        Assert.That(hand.Cards.Count, Is.EqualTo(1));
+        Assert.That(hand.Cards[0].Cost, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void KillingSummonedPawnTwice_ReturnsOnlyOneCard()
+    {
+        var hand = new Hand();
+        var card = new CardData { Cost = 1 };
+        var summon = new SummonUnitPlay(hand, card, true);
+
+        var pawn = summon.Summon();
+        pawn.Kill();
         pawn.Kill();
 
         Assert.That(hand.Cards.Count, Is.EqualTo(1));


### PR DESCRIPTION
## Summary
- prevent multiple kill executions on the same pawn
- update recall logic to modify card instance instead of its controller
- improve test stubs and add coverage for killing the same pawn twice

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj -l trx --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b21486edc832abea8699681b16b17