### PR TITLE
Implement Charge ability

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbility.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbility.cs
@@ -1,0 +1,69 @@
+using System;
+using Runtime.Combat.Tilemap;
+using UnityEngine;
+using Utilities;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [CreateAssetMenu(fileName = "Charge Ability", menuName = "Pawns/Abilities/Combat/Charge", order = 0)]
+    public class ChargeAbility : PawnPlayStrategy
+    {
+        private ChargeAbilityParams _params;
+
+        public override void Play(PawnController pawn, Action<bool> onComplete)
+        {
+            var tilemap = ServiceLocator.Get<TilemapController>();
+            if (tilemap == null)
+            {
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            var forward = pawn.Owner == PawnOwner.Player ? Vector2Int.right : Vector2Int.left;
+            var currentTile = pawn.TilemapHelper.AnchorTile;
+            var steps = _params.MovementDistance;
+
+            for (var i = 0; i < steps; i++)
+            {
+                var nextPos = currentTile.Position + forward;
+                var nextTile = tilemap.GetTile(nextPos);
+                if (nextTile == null)
+                {
+                    break;
+                }
+
+                if (nextTile.IsOccupied)
+                {
+                    PawnHelper.Knockback(nextTile.Pawn, _params.KnockbackStrength, 0, forward);
+                }
+
+                if (nextTile.IsOccupied)
+                {
+                    break;
+                }
+
+                currentTile = nextTile;
+            }
+
+            if (currentTile != pawn.TilemapHelper.AnchorTile)
+            {
+                pawn.MoveToPosition(currentTile, () => onComplete?.Invoke(true));
+            }
+            else
+            {
+                onComplete?.Invoke(false);
+            }
+        }
+
+        public override string GetDescription()
+        {
+            return $"Charge {_params.MovementDistance} and knockback {_params.KnockbackStrength}";
+        }
+
+        public override void Initialize(PawnStrategyData data)
+        {
+            _params = data.Parameters as ChargeAbilityParams;
+            base.Initialize(data);
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbility.cs.meta
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 65b0fd9cbfbb4f239aaf5e96c4e520d2
+timeCreated: 1749925011

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbilityParams.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbilityParams.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Runtime.Combat.Pawn.Abilities
+{
+    [Serializable]
+    public class ChargeAbilityParams : StrategyParams
+    {
+        public int MovementDistance;
+        public int KnockbackStrength;
+    }
+}

--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbilityParams.cs.meta
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/ChargeAbilityParams.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 38d1e5cc31ce4189b5254cd327380008
+timeCreated: 1749925011


### PR DESCRIPTION
## Summary
- add a new `ChargeAbility` pawn strategy
- push a pawn forward and knockback blockers
- include parameters for movement and knockback strength

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbbf03b3c832a9d9cd59fd35bbe8d