### PR TITLE
Implement knockback play strategy

### DIFF
--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackParams.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackParams.cs
@@ -1,0 +1,11 @@
+using System;
+using Runtime.Combat.Pawn;
+
+namespace Runtime.CardGameplay.Card.CardBehaviour
+{
+    [Serializable]
+    public class KnockbackParams : GetPawnsParams
+    {
+        public MovementDirection Direction;
+    }
+}

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackParams.cs.meta
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackParams.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 14ca8958d9c6456296600dd61dda2ce6
+timeCreated: 1743514773

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackTargetCardPlay.cs
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackTargetCardPlay.cs
@@ -1,0 +1,93 @@
+using System;
+using Runtime.Combat.Pawn;
+using Runtime.CardGameplay.Card;
+using UnityEngine;
+
+namespace Runtime.CardGameplay.Card.CardBehaviour
+{
+    [CreateAssetMenu(fileName = "Knockback Play", menuName = "Card/Strategy/Play/Knockback", order = 0)]
+    public class KnockbackTargetCardPlay : CardPlayStrategy
+    {
+        private const int DamagePerTile = 3;
+        private KnockbackParams _params;
+
+        public override void Play(CardController cardController, Action<bool> onComplete)
+        {
+            PawnHelper.SelectPawnsAndInvokeAction(_params,
+                pawn => HandleKnockback(pawn, Potency),
+                cardController.transform.position, onComplete);
+        }
+
+        private void HandleKnockback(PawnController target, int potency)
+        {
+            if (target == null)
+            {
+                Debug.LogError($"Card '{name}' tried to knockback a null target.");
+                return;
+            }
+
+            var direction = CalculateDirection();
+            PawnHelper.Knockback(target, potency, DamagePerTile, direction);
+        }
+
+        private Vector2Int CalculateDirection()
+        {
+            var forward = _params.PawnOwner == PawnOwner.Player ? Vector2Int.right : Vector2Int.left;
+            return _params.Direction switch
+            {
+                MovementDirection.Forward => forward,
+                MovementDirection.Backward => -forward,
+                MovementDirection.Up => Vector2Int.up,
+                MovementDirection.Down => Vector2Int.down,
+                MovementDirection.RandomUpOrDown => Random.value > 0.5f ? Vector2Int.up : Vector2Int.down,
+                MovementDirection.RandomForwardOrBackward => Random.value > 0.5f ? forward : -forward,
+                MovementDirection.Random => InsideUnitTaxicabCircle(),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        private Vector2Int InsideUnitTaxicabCircle()
+        {
+            var x = Random.value * 2 - 1;
+            var y = Random.value * 2 - 1;
+
+            var intX = Mathf.FloorToInt(x);
+            var intY = Mathf.FloorToInt(y);
+            return new Vector2Int(intX, intY);
+        }
+
+        public override string GetDescription()
+        {
+            var relation = _params.PawnOwner == PawnOwner.Player ? "Allied Familiar" : "Hostile Familiar";
+            var builder = new DescriptionBuilder();
+            builder.WithKeyword("Knockback");
+            var directionText = GetDirectionDescription();
+            var knockbackText = $"{builder.GetFormattedText()} {Potency} tiles {directionText}";
+
+            return _params.TargetsCount > 1
+                ? $"{knockbackText} {_params.TargetsCount} {relation}s"
+                : $"{knockbackText} a {relation}";
+        }
+
+        private string GetDirectionDescription()
+        {
+            return _params.Direction switch
+            {
+                MovementDirection.Forward => "forward",
+                MovementDirection.Backward => "backward",
+                MovementDirection.Up => "up",
+                MovementDirection.Down => "down",
+                MovementDirection.RandomUpOrDown => "up or down",
+                MovementDirection.RandomForwardOrBackward => "forward or backward",
+                MovementDirection.Random => "in a random direction",
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        public override void Initialize(PlayStrategyData playStrategyData)
+        {
+            _params = playStrategyData.Parameters as KnockbackParams;
+            base.Initialize(playStrategyData);
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackTargetCardPlay.cs.meta
+++ b/Assets/Scripts/Runtime/CardGameplay/Card/CardBehaviour/KnockbackTargetCardPlay.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 59d56fb537cf46b0811bac0f27c1bf38
+timeCreated: 1743514773


### PR DESCRIPTION
## Summary
- add `KnockbackParams` for knockback play parameters
- compute knockback direction using `MovementDirection`
- update knockback strategy description with direction

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj -clp:v=q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbc13cd4c832a9d0c65690fffebaa