### PR TITLE
Add unit tests for pawn abilities

### DIFF
--- a/Assets/Scripts/Runtime/Combat/Pawn/Abilities/Tests/AbilityTests.cs
+++ b/Assets/Scripts/Runtime/Combat/Pawn/Abilities/Tests/AbilityTests.cs
@@ -1,0 +1,276 @@
+using Runtime.Combat.Pawn.Abilities;
+using Runtime.Combat.Pawn;
+using Runtime.Combat.Tilemap;
+using Runtime.Combat.StatusEffects;
+using Runtime.CardGameplay.Card.View;
+using Utilities;
+using UnityEngine;
+
+namespace AbilityTests
+{
+    public class MoveAbilityTests
+    {
+        [Test]
+        public void GetDescription_Forward()
+        {
+            var ability = new MoveAbility();
+            var data = new PawnStrategyData
+            {
+                Parameters = new MoveDirectionParams { Direction = MovementDirection.Forward },
+                Potency = 2
+            };
+            ability.Initialize(data);
+
+            Assert.That(ability.GetDescription(), Is.EqualTo("Dash 2 tiles forward"));
+        }
+
+        [Test]
+        public void Play_MovesPawnForward()
+        {
+            var tilemap = new TilemapController();
+            var start = new Tile(Vector2Int.zero);
+            var end = new Tile(new Vector2Int(2, 0));
+            tilemap.SetTile(start);
+            tilemap.SetTile(end);
+            ServiceLocator.Register(tilemap);
+
+            var pawn = new PawnController
+            {
+                Owner = PawnOwner.Player,
+                TilemapHelper = { AnchorTile = start }
+            };
+
+            var ability = new MoveAbility();
+            var data = new PawnStrategyData
+            {
+                Parameters = new MoveDirectionParams { Direction = MovementDirection.Forward },
+                Potency = 2
+            };
+            ability.Initialize(data);
+
+            bool result = false;
+            ability.Play(pawn, s => result = s);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(pawn.MoveCalled, Is.True);
+                Assert.That(pawn.LastMoveTile, Is.EqualTo(end));
+                Assert.That(pawn.ExecutedStrategies, Is.SameAs(pawn.Data.OnMoveStrategies));
+            });
+        }
+    }
+
+    public class JumpAbilityTests
+    {
+        [Test]
+        public void ModifyMove_JumpsOverOccupied()
+        {
+            var tilemap = new TilemapController();
+            var start = new Tile(Vector2Int.zero);
+            var block = new Tile(new Vector2Int(1, 0)) { IsOccupied = true };
+            var end = new Tile(new Vector2Int(2, 0));
+            tilemap.SetTile(start);
+            tilemap.SetTile(block);
+            tilemap.SetTile(end);
+            ServiceLocator.Register(tilemap);
+
+            var pawn = new PawnController
+            {
+                Owner = PawnOwner.Player,
+                TilemapHelper = { AnchorTile = start }
+            };
+
+            var ability = new JumpAbility();
+            var next = block;
+            ability.ModifyMove(pawn, ref next);
+
+            Assert.That(next, Is.EqualTo(end));
+        }
+    }
+
+    public class FlyAbilityTests
+    {
+        [Test]
+        public void ModifyMove_FliesOverTiles()
+        {
+            var tilemap = new TilemapController();
+            var start = new Tile(Vector2Int.zero);
+            var block1 = new Tile(new Vector2Int(1, 0)) { IsOccupied = true };
+            var block2 = new Tile(new Vector2Int(2, 0)) { IsOccupied = true };
+            var end = new Tile(new Vector2Int(3, 0));
+            tilemap.SetTile(start);
+            tilemap.SetTile(block1);
+            tilemap.SetTile(block2);
+            tilemap.SetTile(end);
+            ServiceLocator.Register(tilemap);
+
+            var pawn = new PawnController
+            {
+                Owner = PawnOwner.Player,
+                TilemapHelper = { AnchorTile = start }
+            };
+
+            var ability = new FlyAbility();
+            var data = new PawnStrategyData { Potency = 3 };
+            ability.Initialize(data);
+            var next = block1;
+            ability.ModifyMove(pawn, ref next);
+
+            Assert.That(next, Is.EqualTo(end));
+        }
+    }
+
+    public class ChargeAbilityTests
+    {
+        [Test]
+        public void Play_KnockbacksOnCollision()
+        {
+            var tilemap = new TilemapController();
+            var start = new Tile(Vector2Int.zero);
+            var enemyTile = new Tile(new Vector2Int(1, 0)) { IsOccupied = true, Pawn = new PawnController() };
+            tilemap.SetTile(start);
+            tilemap.SetTile(enemyTile);
+            ServiceLocator.Register(tilemap);
+
+            var pawn = new PawnController
+            {
+                Owner = PawnOwner.Player,
+                TilemapHelper = { AnchorTile = start }
+            };
+
+            var ability = new ChargeAbility();
+            var data = new PawnStrategyData
+            {
+                Parameters = new ChargeAbilityParams { MovementDistance = 2, KnockbackStrength = 1 },
+                Potency = 0
+            };
+            ability.Initialize(data);
+
+            ability.Play(pawn, _ => { });
+
+            Assert.That(PawnHelper.LastTarget, Is.EqualTo(enemyTile.Pawn));
+            Assert.That(PawnHelper.LastMagnitude, Is.EqualTo(1));
+        }
+    }
+
+    public class CapturePawnAbilityTests
+    {
+        [Test]
+        public void Play_CallsCapture()
+        {
+            var ability = new CapturePawnAbility();
+            var attacker = new PawnController();
+            var target = new PawnController { CaptureReturn = true };
+            var data = new PawnStrategyData { Potency = 3 };
+            ability.Initialize(data);
+
+            bool result = false;
+            ability.Play(attacker, target, s => result = s);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(target.CapturePotency, Is.EqualTo(3));
+            });
+        }
+    }
+
+    public class KnockbackAbilityTests
+    {
+        [Test]
+        public void Play_UsesPawnHelper()
+        {
+            var ability = new KnockbackAbility();
+            var attacker = new PawnController { Owner = PawnOwner.Player };
+            var target = new PawnController();
+            var data = new PawnStrategyData { Potency = 2 };
+            ability.Initialize(data);
+
+            ability.Play(attacker, target, ref Unsafe.AsRef(0), _ => { });
+
+            Assert.That(PawnHelper.LastTarget, Is.EqualTo(target));
+            Assert.That(PawnHelper.LastMagnitude, Is.EqualTo(2));
+        }
+    }
+
+    public class GainStatusEffectTests
+    {
+        [Test]
+        public void GetDescription_FormatsKeyword()
+        {
+            var keyword = new Keyword { FormattedText = "Poison" };
+            var status = new StatusEffectData { Keyword = keyword };
+            var ability = new GainStatusEffect();
+            var data = new PawnStrategyData
+            {
+                Parameters = new StatusEffectParams { StatusEffect = status },
+                Potency = 1
+            };
+            ability.Initialize(data);
+            var description = ability.GetDescription();
+            Assert.That(description, Is.EqualTo("Gain Poison 1"));
+        }
+
+        [Test]
+        public void Play_AppliesEffect()
+        {
+            var keyword = new Keyword { FormattedText = "Burn" };
+            var status = new StatusEffectData { Keyword = keyword };
+            var ability = new GainStatusEffect();
+            var data = new PawnStrategyData
+            {
+                Parameters = new StatusEffectParams { StatusEffect = status },
+                Potency = 2
+            };
+            ability.Initialize(data);
+            var pawn = new PawnController();
+
+            ability.Play(pawn, _ => { });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pawn.AppliedStatus, Is.EqualTo(status));
+                Assert.That(pawn.AppliedStacks, Is.EqualTo(2));
+            });
+        }
+    }
+
+    public class PawnGainDamagePowerTests
+    {
+        [Test]
+        public void Play_AddsModifier()
+        {
+            var ability = new PawnGainDamagePower();
+            var data = new PawnStrategyData { Potency = 3 };
+            ability.Initialize(data);
+            var pawn = new PawnController();
+
+            ability.Play(pawn, _ => { });
+
+            Assert.That(pawn.Combat.Damage.Modifiers[ability], Is.EqualTo(3));
+        }
+    }
+
+    public class PawnGameOverTests
+    {
+        [Test]
+        public void Play_EndsGame()
+        {
+            var ability = new PawnGameOver();
+            ability.Play(new PawnController(), _ => { });
+            Assert.That(GameManager.Instance.EndRunCalled, Is.True);
+        }
+    }
+
+    public class PawnWinCombatTests
+    {
+        [Test]
+        public void Play_WinsCombat()
+        {
+            var ability = new PawnWinCombat();
+            ability.Play(new PawnController(), _ => { });
+            Assert.That(GameManager.Instance.WinCombatCalled, Is.True);
+        }
+    }
+}

--- a/TakiFight.Tests/AbilityTestStubs.cs
+++ b/TakiFight.Tests/AbilityTestStubs.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Runtime.Combat.Tilemap
+{
+    using Runtime.Combat.Pawn;
+
+    public class Tile
+    {
+        public Vector2Int Position { get; }
+        public bool IsOccupied { get; set; }
+        public PawnController Pawn { get; set; }
+
+        public Tile(Vector2Int position)
+        {
+            Position = position;
+        }
+    }
+
+    public class TilemapController
+    {
+        private readonly Dictionary<Vector2Int, Tile> _tiles = new();
+
+        public void SetTile(Tile tile)
+        {
+            _tiles[tile.Position] = tile;
+        }
+
+        public Tile GetTile(Vector2Int pos)
+        {
+            return _tiles.TryGetValue(pos, out var t) ? t : null;
+        }
+    }
+}
+
+namespace Runtime.Combat.Pawn
+{
+    using Runtime.Combat.StatusEffects;
+    using Utilities;
+
+    public class PawnTilemapHelper
+    {
+        public Tile AnchorTile { get; set; }
+    }
+
+    public class PawnData
+    {
+        public List<PawnStrategyData> OnMoveStrategies { get; } = new();
+    }
+
+    public struct PawnStrategyData
+    {
+        public PawnPlayStrategy Strategy;
+        public StrategyParams Parameters;
+        public int Potency;
+    }
+
+    public class PawnCombat
+    {
+        public Stat Damage { get; } = new Stat();
+    }
+
+    public class PawnController : MonoBehaviour
+    {
+        public PawnOwner Owner { get; set; }
+        public PawnData Data { get; set; } = new PawnData();
+        public PawnTilemapHelper TilemapHelper { get; set; } = new PawnTilemapHelper();
+        public PawnCombat Combat { get; } = new PawnCombat();
+
+        public bool MoveCalled;
+        public Tile LastMoveTile;
+        public void MoveToPosition(Tile tile, Action onComplete)
+        {
+            MoveCalled = true;
+            LastMoveTile = tile;
+            onComplete?.Invoke();
+        }
+
+        public List<PawnStrategyData> ExecutedStrategies { get; private set; }
+        public void ExecuteStrategies(List<PawnStrategyData> strategies)
+        {
+            ExecutedStrategies = strategies;
+        }
+
+        public bool CaptureReturn { get; set; }
+        public int CapturePotency { get; private set; }
+        public bool Capture(int potency)
+        {
+            CapturePotency = potency;
+            return CaptureReturn;
+        }
+
+        public StatusEffectData AppliedStatus;
+        public int AppliedStacks;
+        public void ApplyStatusEffect(StatusEffectData data, int stack)
+        {
+            AppliedStatus = data;
+            AppliedStacks = stack;
+        }
+    }
+
+    public static class PawnHelper
+    {
+        public static PawnController LastTarget;
+        public static int LastMagnitude;
+        public static int LastDamage;
+        public static Vector2Int LastDirection;
+
+        public static void Knockback(PawnController pawn, int magnitude, int damagePerTile, Vector2Int direction, Action<bool> onComplete = null)
+        {
+            LastTarget = pawn;
+            LastMagnitude = magnitude;
+            LastDamage = damagePerTile;
+            LastDirection = direction;
+            onComplete?.Invoke(true);
+        }
+
+        public static void Knockback(PawnController pawn, Vector2Int force, int damagePerTile, Action<bool> onComplete = null)
+        {
+            LastTarget = pawn;
+            LastMagnitude = Math.Abs(force.x) + Math.Abs(force.y);
+            LastDamage = damagePerTile;
+            LastDirection = force;
+            onComplete?.Invoke(true);
+        }
+    }
+}
+
+namespace Utilities
+{
+    using System.Collections.Generic;
+
+    public class Stat
+    {
+        public Dictionary<object, int> Modifiers { get; } = new();
+
+        public void SetModifier(object source, int modifier)
+        {
+            Modifiers[source] = modifier;
+        }
+    }
+}
+
+namespace Runtime.CardGameplay.Card.View
+{
+    using UnityEngine;
+
+    public class Keyword : ScriptableObject
+    {
+        public string FormattedText { get; set; }
+    }
+}
+
+namespace Runtime.Combat.StatusEffects
+{
+    using Runtime.CardGameplay.Card.View;
+    using UnityEngine;
+
+    public class StatusEffectData : ScriptableObject
+    {
+        public Keyword Keyword { get; set; }
+    }
+}
+
+namespace Runtime
+{
+    public class GameManager
+    {
+        public static GameManager Instance { get; } = new GameManager();
+        public bool EndRunCalled;
+        public bool WinCombatCalled;
+
+        public void EndRun()
+        {
+            EndRunCalled = true;
+        }
+
+        public void WinCombat()
+        {
+            WinCombatCalled = true;
+        }
+    }
+}

--- a/TakiFight.Tests/TakiFight.Tests.csproj
+++ b/TakiFight.Tests/TakiFight.Tests.csproj
@@ -16,6 +16,26 @@
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <ProjectReference Include="..\TakiFight.Core\TakiFight.Core.csproj" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\MoveAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\JumpAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\FlyAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\ChargeAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\CapturePawnAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\KnockbackAbility.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\GainStatusEffect.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\PawnGainDamagePower.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\PawnGameOver.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\PawnWinCombat.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\ChargeAbilityParams.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\MoveDirectionParams.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\StatusEffectParams.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\MovementDirection.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\PawnOwner.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\PawnPlayStrategy.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\PawnMovePlayStrategy.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\PawnTargetPlayStrategy.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\PawnHitPlayStrategy.cs" />
+    <Compile Include="..\Assets\Scripts\Runtime\Combat\Pawn\Abilities\Tests\*.cs" />
   </ItemGroup>
 
 </Project>

--- a/TakiFight.Tests/UnityStructs.cs
+++ b/TakiFight.Tests/UnityStructs.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Text;
+
+namespace UnityEngine
+{
+    public struct Vector2Int
+    {
+        public int x;
+        public int y;
+
+        public Vector2Int(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        public static Vector2Int right => new Vector2Int(1, 0);
+        public static Vector2Int left => new Vector2Int(-1, 0);
+        public static Vector2Int up => new Vector2Int(0, 1);
+        public static Vector2Int down => new Vector2Int(0, -1);
+        public static Vector2Int zero => new Vector2Int(0, 0);
+
+        public static Vector2Int operator +(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x + b.x, a.y + b.y);
+        }
+
+        public static Vector2Int operator -(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x - b.x, a.y - b.y);
+        }
+
+        public static Vector2Int operator *(Vector2Int a, int m)
+        {
+            return new Vector2Int(a.x * m, a.y * m);
+        }
+    }
+
+    public static class Random
+    {
+        private static System.Random _rand = new System.Random();
+        public static float value => (float)_rand.NextDouble();
+    }
+
+    public static class Mathf
+    {
+        public static int FloorToInt(float v)
+        {
+            return (int)Math.Floor(v);
+        }
+
+        public static int CeilToInt(float v)
+        {
+            return (int)Math.Ceiling(v);
+        }
+
+        public static int Abs(int v)
+        {
+            return Math.Abs(v);
+        }
+
+        public static float Abs(float v)
+        {
+            return Math.Abs(v);
+        }
+
+        public static int Max(int a, int b)
+        {
+            return Math.Max(a, b);
+        }
+    }
+}
+
+namespace Runtime.CardGameplay.Card
+{
+    using Runtime.CardGameplay.Card.View;
+
+    public class DescriptionBuilder
+    {
+        private readonly StringBuilder _builder = new StringBuilder();
+        private bool _first = true;
+
+        private void NewLine()
+        {
+            if (!_first)
+            {
+                _builder.Append('\n');
+            }
+            _first = false;
+        }
+
+        public DescriptionBuilder WithLine(string line)
+        {
+            if (line != null)
+            {
+                NewLine();
+                _builder.Append(line);
+            }
+            return this;
+        }
+
+        public DescriptionBuilder WithKeyword(Keyword keyword, bool newLine = true)
+        {
+            if (newLine)
+            {
+                NewLine();
+            }
+            _builder.Append(keyword.FormattedText);
+            return this;
+        }
+
+        public DescriptionBuilder AppendInLine(string text)
+        {
+            _builder.Append(text);
+            return this;
+        }
+
+        public string GetFormattedText()
+        {
+            return _builder.ToString().Trim();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add stub Unity structs and helper classes for testing
- compile ability sources in test project
- create extensive tests for pawn abilities

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505b3237ac832a929d750f6baa69e7