### PR TITLE
Add MonoService registration test

### DIFF
--- a/Assets/Tests/EditorMode/MonoServiceTests.cs
+++ b/Assets/Tests/EditorMode/MonoServiceTests.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UnityEngine;
+using Utilities;
+
+namespace Tests.EditorMode
+{
+    public class TestService : MonoService<TestService>
+    {
+    }
+
+    public class MonoServiceTests
+    {
+        [Test]
+        public void RegisterAndUnregisterTestService()
+        {
+            var go = new GameObject("TestService");
+            var service = go.AddComponent<TestService>();
+
+            Assert.That(ServiceLocator.Get<TestService>(), Is.SameAs(service));
+
+            Object.DestroyImmediate(go);
+
+            bool found = ServiceLocator.TryGet(out TestService _);
+            Assert.That(found, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/EditorMode/MonoServiceTests.cs.meta
+++ b/Assets/Tests/EditorMode/MonoServiceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 153f239fe86a4f418c5c9afd2602a55d


### PR DESCRIPTION
## Summary
- add `MonoServiceTests` under EditorMode tests
- confirm `ServiceLocator` registers and unregisters MonoService correctly

## Testing
- `dotnet test TakiFight.Tests/TakiFight.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685bc5ef30c8832abb82307b2214ad5f